### PR TITLE
Settings and compat

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,4 +1,11 @@
 ---------------------------------------------------------------------------------------------------
+Version: 1.0.1
+Date: 2023-12-20
+  Features:
+    - Added a setting to set how long buildings take to make
+  Compatibility:
+    - Recipes keep their origional category to avoid compatibility errors
+---------------------------------------------------------------------------------------------------
 Version: 1.0.0
 Date: 2023-12-20
   Features:

--- a/data-final-fixes.lua
+++ b/data-final-fixes.lua
@@ -2,7 +2,7 @@
 -- Load Settings
 -- =============
 
-local RECIPE_TIME = 0.01
+local RECIPE_TIME = settings.startup["recipe-time"].value
 
 -- ===========================================
 -- Blacklisting & Forcing Item/Recipe Freebies
@@ -91,12 +91,6 @@ local function make_recipe_free(recipe)
 
   recipe.ingredients = {}
   recipe.energy_required = RECIPE_TIME
-
-  -- This "crafting" category should allow most everything to make it, including the player.
-  if (recipe.category)
-  then
-    recipe.category = "crafting"
-  end
 end
 
 -- ================

--- a/info.json
+++ b/info.json
@@ -1,6 +1,6 @@
 {
   "name": "FreeBuildings",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "title": "Free Buildings",
   "author": "Taurunti",
   "contact": "thetaurunti@gmail.com",

--- a/locale/en/locale.cfg
+++ b/locale/en/locale.cfg
@@ -1,0 +1,5 @@
+[mod-setting-name]
+recipe-time=Building Recipe Time
+
+[mod-setting-description]
+recipe-time=How long it takes for a building to be made

--- a/settings.lua
+++ b/settings.lua
@@ -1,0 +1,11 @@
+data:extend({
+  {
+    type = "double-setting",
+    name = "recipe-time",
+    setting_type = "startup",
+    default_value = 0.01,
+    minimum_value = 0.01,
+    maximum_value = 10000,
+    order = "a",
+  },
+})


### PR DESCRIPTION
Added a setting for people to set how long the buildings take to craft. Removed the recipe category, leaving the recipes in their original categories. This removes some compatibility issues. I don't think it breaks anything.