### PR TITLE
set building weight

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,4 +1,9 @@
 ---------------------------------------------------------------------------------------------------
+Version: 1.1.6
+Date: 2025-01-24
+  Features:
+    - Set weight of buildings so that rocket capacity is at least 100, or exactly 100 if unset previously
+---------------------------------------------------------------------------------------------------
 Version: 1.1.5
 Date: 2025-01-23
   Features:

--- a/info.json
+++ b/info.json
@@ -1,6 +1,6 @@
 {
   "name": "FreeBuildings",
-  "version": "1.1.5",
+  "version": "1.1.6",
   "title": "Free Buildings",
   "author": "Taurunti",
   "contact": "thetaurunti@gmail.com",

--- a/utils.lua
+++ b/utils.lua
@@ -37,6 +37,7 @@ end
 
 -- Non-local for mod compats
 function Mult_Item_Stack_Size(item)
+  item.weight = item.weight and math.min(item.weight, 10000) or 10000
   item.stack_size = item.stack_size * ITEM_OUTPUT_AND_STACK_MULT
 end
 


### PR DESCRIPTION
addresses #4 

![image](https://github.com/user-attachments/assets/c8ca2905-3286-4292-8e30-f268a7bc9d61)

the problem was that some items have nil weight so they were set from ingredients and thus the rocket capacity was too large.
